### PR TITLE
Rotate output image + show markers for min an max

### DIFF
--- a/sdl.c
+++ b/sdl.c
@@ -52,6 +52,9 @@
 extern const uint8_t builtin_ttf_start;
 extern const uint8_t builtin_ttf_end;
 
+static const SDL_Color SDL_COLOR_RED = {0xFF, 0, 0, 0xFF};
+static const SDL_Color SDL_COLOR_BLUE = {0, 0, 0xFF, 0xFF};
+
 /*
  * Lookup table for the Turbo colormap (see README).
  */
@@ -165,6 +168,7 @@ struct sdl_ctx {
 	FILE *fonttmp;
 	bool colormap;
 	bool showtext;
+	bool show_min_max_marker;
 	bool fahren;
 	int gammafactor;
 	int contours;
@@ -176,8 +180,7 @@ struct sdl_ctx {
 	time_t inittsmono;
 	uint16_t scale_max;
 	uint16_t scale_min;
-	int crosshair_x;
-	int crosshair_y;
+	SDL_Point crosshair;
 	struct lavc_ctx *vrecord;
 	uint32_t frame_paint_seq;
 	uint8_t textval;
@@ -321,16 +324,17 @@ static void showhelptext(struct sdl_ctx *c)
 	drawtext(c, 40, 72, "R: TOGGLE Y16 RECORD");
 	drawtext(c, 40, 79, "V: TOGGLE RGBA RECORD");
 	drawtext(c, 40, 86, "T: TOGGLE TXT COLOR/ON/OFF");
-	drawtext(c, 40, 93, "G: TOGGLE GAMMA CORR");
-	drawtext(c, 40, 100, "Y: TOGGLE CONTOURING");
-	drawtext(c, 40, 107, "F: TOGGLE UNITS F/C");
-	drawtext(c, 40, 114, "I: TOGGLE INVERT");
-	drawtext(c, 40, 121, "U: TOGGLE OUTPUT ROTATION");
-	drawtext(c, 40, 128, "C: TOGGLE GRAYSCALE");
-	drawtext(c, 40, 135, "ARROW KEYS MOVE CROSS");
-	drawtext(c, 40, 142, "SPACEBAR PAUSES PLAYBACK");
-	drawtext(c, 40, 149, "L: SHOW LICENSE DETAILS");
-	drawtext(c, 40, 156, "H: SHOW THIS HELP TEXT");
+	drawtext(c, 40, 93, "M: TOGGLE SHOW MIN/MAX MARKER");
+	drawtext(c, 40, 100, "G: TOGGLE GAMMA CORR");
+	drawtext(c, 40, 107, "Y: TOGGLE CONTOURING");
+	drawtext(c, 40, 114, "F: TOGGLE UNITS F/C");
+	drawtext(c, 40, 121, "I: TOGGLE INVERT");
+	drawtext(c, 40, 128, "U: TOGGLE OUTPUT ROTATION");
+	drawtext(c, 40, 135, "C: TOGGLE GRAYSCALE");
+	drawtext(c, 40, 142, "ARROW KEYS MOVE CROSS");
+	drawtext(c, 40, 149, "SPACEBAR PAUSES PLAYBACK");
+	drawtext(c, 40, 156, "L: SHOW LICENSE DETAILS");
+	drawtext(c, 40, 163, "H: SHOW THIS HELP TEXT");
 }
 
 static void sdl_open_fontcache(struct sdl_ctx *c)
@@ -396,6 +400,10 @@ static int sdl_poll_one(struct sdl_ctx *c, SDL_Event *evt, uint16_t min,
 				c->showtext = 0;
 			}
 
+			break;
+
+		case SDL_SCANCODE_M:
+			c->show_min_max_marker = !c->show_min_max_marker;
 			break;
 
 		case SDL_SCANCODE_F:
@@ -480,30 +488,30 @@ static int sdl_poll_one(struct sdl_ctx *c, SDL_Event *evt, uint16_t min,
 			break;
 
 		case SDL_SCANCODE_RIGHT:
-			c->crosshair_x++;
-			if (c->crosshair_x >= WIDTH)
-				c->crosshair_x = 0;
+			c->crosshair.x++;
+			if (c->crosshair.x >= WIDTH)
+				c->crosshair.x = 0;
 
 			break;
 
 		case SDL_SCANCODE_LEFT:
-			c->crosshair_x--;
-			if (c->crosshair_x < 0)
-				c->crosshair_x = WIDTH - 1;
+			c->crosshair.x--;
+			if (c->crosshair.x < 0)
+				c->crosshair.x = WIDTH - 1;
 
 			break;
 
 		case SDL_SCANCODE_UP:
-			c->crosshair_y--;
-			if (c->crosshair_y < 0)
-				c->crosshair_x = HEIGHT - 1;
+			c->crosshair.y--;
+			if (c->crosshair.y < 0)
+				c->crosshair.y = HEIGHT - 1;
 
 			break;
 
 		case SDL_SCANCODE_DOWN:
-			c->crosshair_y++;
-			if (c->crosshair_y >= HEIGHT)
-				c->crosshair_x = 0;
+			c->crosshair.y++;
+			if (c->crosshair.y >= HEIGHT)
+				c->crosshair.y = 0;
 
 			break;
 
@@ -525,6 +533,36 @@ static int sdl_poll_one(struct sdl_ctx *c, SDL_Event *evt, uint16_t min,
 	return NOTHING;
 }
 
+static SDL_Point calc_point_from_buf_offset(const struct sdl_ctx *c, const int offset)
+{
+	if (c->rotate) {
+		return (SDL_Point){ WIDTH - (offset / 2 % WIDTH), HEIGHT - (offset / 2 / WIDTH) };
+	}
+
+	return (SDL_Point){ offset / 2 % WIDTH, offset / 2 / WIDTH };
+}
+
+/**
+ * paint_colored_marker() - Paint a marker (cross) given a center point, a size and a color.
+ *
+ * @param c SDL context handle.
+ * @param center_point The center point of the marker.
+ * @param size The size (radius) of the marker.
+ * @param color The color to use for the marker.
+ */
+static void paint_colored_marker(const struct sdl_ctx *c, const SDL_Point center_point, const int size, const SDL_Color color)
+{
+	Uint8 original_red_color;
+	Uint8 original_green_color;
+	Uint8 original_blue_color;
+	Uint8 original_alpha;
+	SDL_GetRenderDrawColor(c->r, &original_red_color, &original_green_color, &original_blue_color, &original_alpha);
+	SDL_SetRenderDrawColor(c->r, color.r, color.g, color.b, color.a);
+	SDL_RenderDrawLine(c->r, center_point.x, center_point.y - size, center_point.x, center_point.y + size);
+	SDL_RenderDrawLine(c->r, center_point.x - size, center_point.y, center_point.x + size, center_point.y);
+	SDL_SetRenderDrawColor(c->r, original_red_color, original_green_color, original_blue_color, original_alpha);
+}
+
 /**
  * paint_frame() - Paint a new frame in the SDL window.
  * @param c SDL context handle.
@@ -538,6 +576,8 @@ static int sdl_poll_one(struct sdl_ctx *c, SDL_Event *evt, uint16_t min,
 int paint_frame(struct sdl_ctx *c, uint32_t seq, const uint8_t *data)
 {
 	uint16_t min = UINT16_MAX, max = 0, ptemp;
+	SDL_Point min_point = {0, 0};
+	SDL_Point max_point = {0, 0};
 	uint16_t orig_min, orig_max;
 	uint32_t multinv;
 	uint32_t output_index;
@@ -548,7 +588,7 @@ int paint_frame(struct sdl_ctx *c, uint32_t seq, const uint8_t *data)
 	SDL_Rect rect;
 
 	// Get temperature at crosshair
-	i = c->crosshair_y * WIDTH * 2 + c->crosshair_x * 2;
+	i = c->crosshair.y * WIDTH * 2 + c->crosshair.x * 2;
 	if (c->rotate) {
 		// Mirror crosshair if output is rotated
 		i = WIDTH * HEIGHT * 2 - i;
@@ -557,8 +597,14 @@ int paint_frame(struct sdl_ctx *c, uint32_t seq, const uint8_t *data)
 
 	for (i = 0; i < WIDTH * HEIGHT * 2; i += 2) {
 		uint16_t v = data[i] | data[i + 1] << 8;
-		max = v > max ? v : max;
-		min = v < min ? v : min;
+		if (v > max) {
+			max = v;
+			max_point = calc_point_from_buf_offset(c, i);
+		}
+		if (v < min) {
+			min = v;
+			min_point = calc_point_from_buf_offset(c, i);
+		}
 	}
 
 	rect.y = 0;
@@ -639,10 +685,12 @@ skippaint:
 		showtexts(c, raw_to_celsius(orig_max), raw_to_celsius(ptemp),
 			  raw_to_celsius(orig_min), seq);
 
-		SDL_RenderDrawLine(c->r, c->crosshair_x, c->crosshair_y - 2,
-				   c->crosshair_x, c->crosshair_y + 2);
-		SDL_RenderDrawLine(c->r, c->crosshair_x - 2, c->crosshair_y,
-				   c->crosshair_x + 2, c->crosshair_y);
+		paint_colored_marker(c, c->crosshair, 2, (SDL_Color){c->textval, c->textval, c->textval, 0xFF});
+
+		if (c->show_min_max_marker) {
+			paint_colored_marker(c, min_point, 1, SDL_COLOR_BLUE);
+			paint_colored_marker(c, max_point, 1, SDL_COLOR_RED);
+		}
 	}
 
 	if (c->showhelp)
@@ -661,7 +709,7 @@ skippaint:
 /**
  * sdl_open() - Create a new SDL window.
  * @param upscaled_width Real pixel width of window on desktop.
- * @param upscaled_heigth Real pixel height of window on desktop.
+ * @param upscaled_height Real pixel height of window on desktop.
  * @param pb True for playback mode.
  * @param fontpath Path to font for rendering text.
  *
@@ -702,8 +750,8 @@ struct sdl_ctx *sdl_open(int upscaled_width, int upscaled_height, bool pb,
 	c->showtext = 1;
 	c->fahren = 1;
 	c->contours = 1;
-	c->crosshair_x = WIDTH / 2;
-	c->crosshair_y = HEIGHT / 2;
+	c->crosshair.x = WIDTH / 2;
+	c->crosshair.y = HEIGHT / 2;
 	c->textval = 255;
 	c->fontpath = strdup(fontpath);
 	c->fonttmp = font_tmpfile;

--- a/sdl.c
+++ b/sdl.c
@@ -687,7 +687,7 @@ skippaint:
 
 		paint_colored_marker(c, c->crosshair, 2, (SDL_Color){c->textval, c->textval, c->textval, 0xFF});
 
-		if (c->show_min_max_marker) {
+		if (c->show_min_max_marker && !c->paused) {
 			paint_colored_marker(c, min_point, 1, SDL_COLOR_BLUE);
 			paint_colored_marker(c, max_point, 1, SDL_COLOR_RED);
 		}


### PR DESCRIPTION
This implements support for rotating the output image by 180° when a camera is plugged in upside down (possible with USB-C) using a hotkey (U). It also implements a hotkey to show a marker in the output image for the minimum and maximum temperature (M).

I can also create a separate pull request for only the rotation part, but the current implementation of the min/max markers depends on the rotation changes (because of refactoring).